### PR TITLE
Fix typos in Interpreter comments

### DIFF
--- a/src/main/java/com/example/Interpreter.java
+++ b/src/main/java/com/example/Interpreter.java
@@ -125,7 +125,7 @@ class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
                 return isEqual(left, right);
         }
          
-        // Unreacheable
+        // Unreachable
         return null;
     }
 
@@ -152,7 +152,7 @@ class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
                 return -(double)right;
         }
 
-        // Unreacheable
+        // Unreachable
         return null;
     }
 


### PR DESCRIPTION
## Summary
- fix typo in `Interpreter.java` comments

## Testing
- `mvn -q test` *(fails: `mvn` not found)*