### PR TITLE
Fix comment scanning loop condition

### DIFF
--- a/src/main/java/com/example/Scanner.java
+++ b/src/main/java/com/example/Scanner.java
@@ -78,7 +78,7 @@ public class Scanner
                 break;
             case '/':
                 if (match('/')) {
-                    while(peek() != '\n' || isAtEnd()) advance();
+                    while (peek() != '\n' && !isAtEnd()) advance();
                 } else {
                     addToken(TokenType.SLASH);
                 }


### PR DESCRIPTION
## Summary
- correct logic for skipping line comments

## Testing
- `mvn -q test` *(fails: `mvn` not found)*